### PR TITLE
Update CRUDServiceBase.ts

### DIFF
--- a/common/services/CRUDServiceBase.ts
+++ b/common/services/CRUDServiceBase.ts
@@ -14,7 +14,7 @@ export default abstract class CRUDServiceBase<DataType extends DataTypeBase, Rec
     dataAccessor: DataAccessorBase<RecordType>,
     dataToRecord: (data: DataType) => RecordType,
     recordToData: (record: RecordType) => DataType,
-    useCache: boolean = true
+    useCache: boolean = false
   ) {
     this.dataAccessor = dataAccessor;
     this.dataToRecord = dataToRecord;


### PR DESCRIPTION
This pull request makes a small but important change to the `CRUDServiceBase` class. The default value for the `useCache` parameter in the constructor has been changed from `true` to `false`. This means that, unless specified otherwise, caching will now be disabled by default when creating instances of this service.