### PR TITLE
Fix Dockerfile COPY command for typescript-common directory

### DIFF
--- a/client/finance/Dockerfile
+++ b/client/finance/Dockerfile
@@ -11,7 +11,7 @@ ARG NEXTAUTH_URL
 
 WORKDIR /app
 
-COPY typescript-common ./typescript-common/common
+COPY typescript-common/common ./typescript-common/common
 COPY finance ./finance
 COPY nextjs-common/common ./nextjs-common/common
 COPY client/finance ./client/finance

--- a/server/finance/Dockerfile
+++ b/server/finance/Dockerfile
@@ -10,7 +10,7 @@ ARG PROJECT_AWS_REGION
 
 WORKDIR /app
 
-COPY typescript-common ./typescript-common/common
+COPY typescript-common/common ./typescript-common/common
 COPY finance ./finance
 COPY server/common ./server/common
 COPY server/finance ./server/finance


### PR DESCRIPTION
Correct the COPY command in the Dockerfile to accurately reference the typescript-common directory.