### PR TITLE
v1.10.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Rewrite ads.txt content from secrets
       run: |
-        sed -i 's|{{ PublisherID }}|${{ env.GOOGLE_ADSENSE_PUBLISHER_ID }}|g' client/tools/public/ads.txt
+        sed -i 's|{{ PublisherID }}|${{ env.GOOGLE_ADSENSE_PUBLISHER_ID }}|g' client/finance/public/ads.txt
 
     - name: Deploy
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,13 @@ jobs:
           AWS_SECRETS, AWS
         parse-json-secrets: true
 
+    - name: Get Secrets from Google AdSense
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          GOOGLE_ADSENSE, GoogleAdSense
+        parse-json-secrets: true
+
     - name: Get Project Secrets from Finance
       if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       uses: aws-actions/aws-secretsmanager-get-secrets@v2
@@ -60,6 +67,10 @@ jobs:
     - name: Rewrite sw.js endpoint from secrets
       run: |
         sed -i 's|http://localhost:3000|${{ env.PROJECT_CLIENT_BASE_URL }}|g' client/finance/public/sw.js
+
+    - name: Rewrite ads.txt content from secrets
+      run: |
+        sed -i 's|{{ PublisherID }}|${{ env.GOOGLE_ADSENSE_PUBLISHER_ID }}|g' client/tools/public/ads.txt
 
     - name: Deploy
       run: |

--- a/client/finance/public/ads.txt
+++ b/client/finance/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, {{ PublisherID }}, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request updates the deployment workflow to support dynamic configuration of the `ads.txt` file for Google AdSense integration, and updates the `typescript-common` submodule. The main focus is on securely retrieving AdSense secrets and injecting them into the static asset during deployment.

**Deployment workflow improvements:**

* Added a step to retrieve Google AdSense secrets from AWS Secrets Manager in the deployment workflow (`.github/workflows/deploy.yml`).
* Added a step to rewrite the `ads.txt` file by replacing the `{{ PublisherID }}` placeholder with the actual publisher ID from secrets during deployment (`.github/workflows/deploy.yml`).

**Static asset changes:**

* Created a template for `ads.txt` with a `{{ PublisherID }}` placeholder to be replaced during deployment (`client/finance/public/ads.txt`).

**Submodule update:**

* Updated the `typescript-common` submodule to the latest commit.